### PR TITLE
Upgrade Superpower from 2.3.0 to 3.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,10 @@ The `GraphZen.DevCli` project contains code generation utilities:
 dotnet run --project src/GraphZen.DevCli/GraphZen.DevCli.csproj gen
 ```
 
+## Related Repositories
+
+- **Superpower** (parsing library) - Local clone at `~/Code/datalust/superpower` (upstream: https://github.com/datalust/superpower). Used by `GraphZen.LanguageModel` for GraphQL parsing.
+
 ## Code Style
 
 - Nullable reference types enabled (`<Nullable>enable</Nullable>`)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageVersion Include="Superpower" Version="2.3.0" />
+    <PackageVersion Include="Superpower" Version="3.1.0" />
     <PackageVersion Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
     <!-- Test dependencies -->
     <PackageVersion Include="CompareNETObjects" Version="4.84.0" />


### PR DESCRIPTION
## Summary
- Upgrades the Superpower parsing library from 2.3.0 to 3.1.0
- Superpower 3.x adds nullable reference type annotations, performance improvements, and new combinators (`OneOf`, `Where`, `Span.Except`)
- No breaking API changes — all 610 tests pass without code modifications
- Adds a Related Repositories section to CLAUDE.md documenting the local Superpower clone

## Test plan
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] `dotnet test` passes all 610 tests (17 skipped, unchanged from before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)